### PR TITLE
Rename `static` and `dynamic` types to fix compilation with OTP26+

### DIFF
--- a/lib/plug_cache_control.ex
+++ b/lib/plug_cache_control.ex
@@ -93,11 +93,14 @@ defmodule PlugCacheControl do
   alias Plug.Conn
   alias PlugCacheControl.Helpers
 
-  @typep static :: Helpers.directive_opt()
-  @typep dynamic :: (Plug.Conn.t() -> Helpers.directive_opt())
+  @typep static_dir :: Helpers.directive_opt()
+  @typep dynamic_dir :: (Plug.Conn.t() -> Helpers.directive_opt())
 
   @impl Plug
-  @spec init([{:directives, static | dynamic}]) :: %{directives: dynamic, replace: boolean()}
+  @spec init([{:directives, static_dir() | dynamic_dir()}]) :: %{
+          directives: dynamic_dir(),
+          replace: boolean()
+        }
   def init(opts) do
     opts
     |> Enum.into(%{})
@@ -106,7 +109,8 @@ defmodule PlugCacheControl do
   end
 
   @impl Plug
-  @spec call(Conn.t(), %{directives: static() | dynamic(), replace: boolean()}) :: Conn.t()
+  @spec call(Conn.t(), %{directives: static_dir() | dynamic_dir(), replace: boolean()}) ::
+          Conn.t()
   def call(conn, %{directives: fun} = opts) when is_function(fun, 1) do
     opts = Map.put(opts, :directives, fun.(conn))
 


### PR DESCRIPTION
OTP26 introduces a [new `dynamic` type](https://www.erlang.org/downloads/26#dialyzer) that interferes with the one defined in this library.

It prevents compilation from completing.

This PR renames `static` and `dynamic` types to `static_dir` and `dynamic_dir` so as to fix this issue.